### PR TITLE
Add contacts API with form

### DIFF
--- a/app/api/contacts/data.ts
+++ b/app/api/contacts/data.ts
@@ -1,0 +1,79 @@
+import { Contact } from '@/types/contact';
+
+export let contacts: Contact[] = [
+  {
+    id: '1',
+    name: 'Sarah Martin',
+    type: 'member',
+    role: 'Chanteuse principale',
+    email: 'sarah.martin@email.com',
+    phone: '+33 6 12 34 56 78',
+    address: '12 rue de la Musique, 75011 Paris',
+    avatar: 'SM',
+    status: 'active',
+    joinDate: '2023-01-15'
+  },
+  {
+    id: '2',
+    name: 'Studio Central',
+    type: 'venue',
+    role: 'Studio de répétition',
+    email: 'contact@studiocentral.fr',
+    phone: '+33 1 42 85 96 74',
+    address: '45 avenue des Arts, 75011 Paris',
+    avatar: 'SC',
+    status: 'active',
+    services: ['Répétition', 'Enregistrement'],
+    hourlyRate: '25€/h'
+  },
+  {
+    id: '3',
+    name: 'Mike Wilson',
+    type: 'member',
+    role: 'Batteur',
+    email: 'mike.wilson@email.com',
+    phone: '+33 6 87 65 43 21',
+    address: '8 boulevard Saint-Michel, 75006 Paris',
+    avatar: 'MW',
+    status: 'active',
+    joinDate: '2023-03-22'
+  },
+  {
+    id: '4',
+    name: 'Salle des Fêtes Mairie 12e',
+    type: 'venue',
+    role: 'Salle de concert',
+    email: 'evenements@mairie12.paris.fr',
+    phone: '+33 1 44 68 12 34',
+    address: '130 avenue Daumesnil, 75012 Paris',
+    avatar: 'SF',
+    status: 'active',
+    capacity: '200 personnes',
+    services: ['Concert', 'Événement privé']
+  },
+  {
+    id: '5',
+    name: 'Jean Dupont',
+    type: 'provider',
+    role: 'Ingénieur du son',
+    email: 'jean.dupont@soundtech.fr',
+    phone: '+33 6 45 78 96 32',
+    address: '23 rue Oberkampf, 75011 Paris',
+    avatar: 'JD',
+    status: 'active',
+    services: ['Sonorisation', 'Enregistrement'],
+    dailyRate: '350€/jour'
+  },
+  {
+    id: '6',
+    name: 'Emma Brown',
+    type: 'member',
+    role: 'Bassiste',
+    email: 'emma.brown@email.com',
+    phone: '+33 6 23 45 67 89',
+    address: '67 rue de Charonne, 75011 Paris',
+    avatar: 'EB',
+    status: 'inactive',
+    joinDate: '2022-11-10'
+  }
+];

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { contacts } from './data';
+import { Contact } from '@/types/contact';
+
+export async function GET() {
+  return NextResponse.json(contacts);
+}
+
+export async function POST(request: Request) {
+  const data = (await request.json()) as Partial<Contact>;
+  const newContact: Contact = {
+    id: Date.now().toString(),
+    name: data.name || '',
+    type: data.type || 'member',
+    role: data.role,
+    email: data.email,
+    phone: data.phone,
+    address: data.address,
+    avatar: data.avatar || (data.name ? data.name.split(' ').map(w => w[0]).join('').toUpperCase() : ''),
+    status: data.status || 'active',
+    joinDate: new Date().toISOString().split('T')[0],
+    services: data.services,
+    hourlyRate: data.hourlyRate,
+    dailyRate: data.dailyRate,
+    capacity: data.capacity,
+  };
+  contacts.push(newContact);
+  return NextResponse.json(newContact, { status: 201 });
+}

--- a/components/dashboard/ContactsTab.tsx
+++ b/components/dashboard/ContactsTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { Contact } from '@/types/contact';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -22,83 +23,39 @@ export default function ContactsTab() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
 
-  const contacts = [
-    {
-      id: '1',
-      name: 'Sarah Martin',
-      type: 'member',
-      role: 'Chanteuse principale',
-      email: 'sarah.martin@email.com',
-      phone: '+33 6 12 34 56 78',
-      address: '12 rue de la Musique, 75011 Paris',
-      avatar: 'SM',
-      status: 'active',
-      joinDate: '2023-01-15'
-    },
-    {
-      id: '2',
-      name: 'Studio Central',
-      type: 'venue',
-      role: 'Studio de répétition',
-      email: 'contact@studiocentral.fr',
-      phone: '+33 1 42 85 96 74',
-      address: '45 avenue des Arts, 75011 Paris',
-      avatar: 'SC',
-      status: 'active',
-      services: ['Répétition', 'Enregistrement'],
-      hourlyRate: '25€/h'
-    },
-    {
-      id: '3',
-      name: 'Mike Wilson',
-      type: 'member',
-      role: 'Batteur',
-      email: 'mike.wilson@email.com',
-      phone: '+33 6 87 65 43 21',
-      address: '8 boulevard Saint-Michel, 75006 Paris',
-      avatar: 'MW',
-      status: 'active',
-      joinDate: '2023-03-22'
-    },
-    {
-      id: '4',
-      name: 'Salle des Fêtes Mairie 12e',
-      type: 'venue',
-      role: 'Salle de concert',
-      email: 'evenements@mairie12.paris.fr',
-      phone: '+33 1 44 68 12 34',
-      address: '130 avenue Daumesnil, 75012 Paris',
-      avatar: 'SF',
-      status: 'active',
-      capacity: '200 personnes',
-      services: ['Concert', 'Événement privé']
-    },
-    {
-      id: '5',
-      name: 'Jean Dupont',
-      type: 'provider',
-      role: 'Ingénieur du son',
-      email: 'jean.dupont@soundtech.fr',
-      phone: '+33 6 45 78 96 32',
-      address: '23 rue Oberkampf, 75011 Paris',
-      avatar: 'JD',
-      status: 'active',
-      services: ['Sonorisation', 'Enregistrement'],
-      dailyRate: '350€/jour'
-    },
-    {
-      id: '6',
-      name: 'Emma Brown',
-      type: 'member',
-      role: 'Bassiste',
-      email: 'emma.brown@email.com',
-      phone: '+33 6 23 45 67 89',
-      address: '67 rue de Charonne, 75011 Paris',
-      avatar: 'EB',
-      status: 'inactive',
-      joinDate: '2022-11-10'
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newEmail, setNewEmail] = useState('');
+  const [newRole, setNewRole] = useState('');
+
+  useEffect(() => {
+    fetch('/api/contacts')
+      .then(res => res.json())
+      .then(data => setContacts(data));
+  }, []);
+
+  const handleAddContact = async () => {
+    const body = {
+      name: newName,
+      email: newEmail,
+      role: newRole,
+      type: 'member'
+    };
+    const res = await fetch('/api/contacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (res.ok) {
+      const created = await res.json();
+      setContacts(prev => [...prev, created]);
+      setShowForm(false);
+      setNewName('');
+      setNewEmail('');
+      setNewRole('');
     }
-  ];
+  };
 
   const categories = [
     { id: 'all', label: 'Tous', count: contacts.length },
@@ -167,11 +124,39 @@ export default function ContactsTab() {
           <h2 className="text-3xl font-bold text-white mb-2">Carnet de Contacts</h2>
           <p className="text-slate-400">Gérez tous vos contacts musicaux en un seul endroit</p>
         </div>
-        <Button className="bg-blue-600 hover:bg-blue-700">
+        <Button className="bg-blue-600 hover:bg-blue-700" onClick={() => setShowForm(!showForm)}>
           <Plus className="h-4 w-4 mr-2" />
           Nouveau contact
         </Button>
       </div>
+
+      {showForm && (
+        <Card className="bg-slate-800/50 border-slate-700">
+          <CardContent className="pt-6 space-y-4">
+            <Input
+              placeholder="Nom"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              className="bg-slate-900/50 border-slate-600 text-white"
+            />
+            <Input
+              placeholder="Email"
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              className="bg-slate-900/50 border-slate-600 text-white"
+            />
+            <Input
+              placeholder="Rôle"
+              value={newRole}
+              onChange={(e) => setNewRole(e.target.value)}
+              className="bg-slate-900/50 border-slate-600 text-white"
+            />
+            <Button className="bg-blue-600 hover:bg-blue-700" onClick={handleAddContact}>
+              Ajouter
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Search and Filters */}
       <Card className="bg-slate-800/50 border-slate-700">

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/types/contact.ts
+++ b/types/contact.ts
@@ -1,0 +1,16 @@
+export interface Contact {
+  id: string;
+  name: string;
+  type: string;
+  role?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  avatar?: string;
+  status?: string;
+  joinDate?: string;
+  services?: string[];
+  hourlyRate?: string;
+  dailyRate?: string;
+  capacity?: string;
+}


### PR DESCRIPTION
## Summary
- add Contact type definition
- implement in-memory contacts API
- fetch & add new contacts with a simple form
- remove `output: 'export'` so Next.js can run API routes

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859ea3d01888326a5ad009c3c551474